### PR TITLE
fix KaTeX rendering and little typo

### DIFF
--- a/docs/notes/sep-logic.md
+++ b/docs/notes/sep-logic.md
@@ -216,7 +216,7 @@ $\assert{e} ::= \ife{e}{()}{\num{1} == \true}$ (evaluates to $()$ if $e$ is true
 
 What you need to know about $\operatorname{assert}$ is really just that it has the following specification:
 
-$$\hoare{\True}{\assert{\true}}{\fun{v} \lift{v = ()}}$$.
+$$\hoare{\True}{\assert{\true}}{\fun{v} \lift{v = ()}}$$
 
 :::
 

--- a/docs/notes/sep-logic.md
+++ b/docs/notes/sep-logic.md
@@ -410,7 +410,7 @@ Using this rule, we can prove that $sumN$ returns $\num{n(n+1)/2}$. The key is t
 
 ## Magic wand (separating implication)
 
-There is one more operator for separation logic assertions: $P \wand Q$, typically pronounced "$P$ wand $Q$". It is often affectionally called "magic wand". $P \wand Q$ is a _heap predicate_ that is true in a (sub)heap if when you add some disjoint heap satisfying $P$, the whole heap would satisfy $Q$. The wand operator is the implication of separation logic.
+There is one more operator for separation logic assertions: $P \wand Q$, typically pronounced "$P$ wand $Q$". It is often affectionately called "magic wand". $P \wand Q$ is a _heap predicate_ that is true in a (sub)heap if when you add some disjoint heap satisfying $P$, the whole heap would satisfy $Q$. The wand operator is the implication of separation logic.
 
 ::: info Characterization of wand
 


### PR DESCRIPTION
Before:

<img width="861" alt="image" src="https://github.com/user-attachments/assets/9e85e6cd-4207-4ac9-8326-3fb4c260d9e1">

After:

<img width="807" alt="image" src="https://github.com/user-attachments/assets/76a7177e-35c0-4806-a8f3-26d458bff9ab">

Typo: affectionally -> affectionately
