### PR TITLE
Fix free variables in assignment 2 code snippets

### DIFF
--- a/docs/assignments/assignment2.md
+++ b/docs/assignments/assignment2.md
@@ -154,7 +154,7 @@ Fixpoint app_list (l1: ref (llist A)) (l2: ref (llist A)) :=
   match !l1 with
   | lnil => l1 <- !l2; free l2; ()
   | lcons hd tl => app_list tl y
-  end
+  end.
 ```
 
 Write a specification for `app_list l1 l2`. **You may assume an affine separation logic**, so the postcondition can drop any facts you don't think are relevant.
@@ -178,6 +178,7 @@ Definition tail (l: llist A) : llist A :=
 match l with
 | lnil => ()
 | lcons hd tl => !tl
+end.
 ```
 
 Consider the following specification for `tail`:

--- a/docs/assignments/assignment2.md
+++ b/docs/assignments/assignment2.md
@@ -115,9 +115,9 @@ To specify functions over linked lists, we will use the following _representatio
 
 ```coq
 Fixpoint list_rep (v: llist A) (xs: list A): hProp :=
-  match x with
+  match xs with
   | [] => v = lnil
-  | hd :: x2 => ∃ tl l',
+  | hd :: xs' => ∃ tl l',
      (l = lcons hd tl) ∗
      (tl ↦ l') ∗
      list_rep l' xs'
@@ -175,7 +175,7 @@ Let us now implement a function to get the tail of a list:
 
 ```coq title="expr"
 Definition tail (l: llist A) : llist A :=
-match x with
+match l with
 | lnil => ()
 | lcons hd tl => !tl
 ```


### PR DESCRIPTION
In the `list_rep` definition,
```coq
Fixpoint list_rep (v: llist A) (xs: list A): hProp :=
  match x with
  | [] => v = lnil
  | hd :: x2 => ∃ tl l',
     (l = lcons hd tl) ∗
     (tl ↦ l') ∗
     list_rep l' xs'
   end.
```
we see `match x with` but `x` isn't bound here. I think that this should be matching on `xs`, the logical list. Later in the definition we see `list_rep l' xs'` but similarly `xs'` isn't bound either. 

Later in question 5 (d), we see the definition of `tail`, 
```coq
Definition tail (l: llist A) : llist A :=
match x with
| lnil => ()
| lcons hd tl => !tl
```
the `match` statement also references an undefined `x`. We should be matching on `l` here. 