### PR TITLE
better formatting for `for`

### DIFF
--- a/docs/notes/sep-logic.md
+++ b/docs/notes/sep-logic.md
@@ -382,17 +382,15 @@ $$
 \begin{aligned}
 &\for ::= \\
 &\quad \fun{n, f} \\
-&\quad \lete{g}{\\
+&\quad \text{\textbf{let}} \; g :=\\
 &\quad\quad\begin{aligned}
 &\rec{loop}{i} \\
-&\quad\ife{(i = n)}{()}{f \, i\then loop \, (i + 1)} \\
-\end{aligned}
-} \\
-&\quad g
+&\quad\quad\text{\textbf{if} } (i = n) \text{ \textbf{then} } () \\
+&\quad\quad\text{\textbf{else} } f \, i\then loop \, (i + 1) \; \text{\textbf{in}}
+\end{aligned} \\
+&\quad g \; 0
 \end{aligned}
 $$
-
-(Apologies for the formatting, still working on it.)
 
 :::
 


### PR DESCRIPTION
Before:
<img width="462" alt="image" src="https://github.com/user-attachments/assets/4fe23f54-3e85-45b1-b19d-36dbfbf735ee">

After:
<img width="720" alt="image" src="https://github.com/user-attachments/assets/6d405463-ee36-461f-934d-d5bd33064c86">

I don't know why we need to define function $g$ here, it seems redundant.
