### PR TITLE
Update assignment2.md

### DIFF
--- a/docs/assignments/assignment2.md
+++ b/docs/assignments/assignment2.md
@@ -153,7 +153,7 @@ Consider the following function for appending two linked lists. It's your job to
 Fixpoint app_list (l1: ref (llist A)) (l2: ref (llist A)) :=
   match !l1 with
   | lnil => l1 <- !l2; free l2; ()
-  | lcons hd tl => app_list tl y
+  | lcons hd tl => app_list tl l2
   end.
 ```
 


### PR DESCRIPTION
I am not sure where 'y' come from in Prob 5. I think it is more rational to see it as a typo of 'l2'.
```
Fixpoint app_list (l1: ref (llist A)) (l2: ref (llist A)) :=
  match !l1 with
  | lnil => l1 <- !l2; free l2; ()
  | lcons hd tl => app_list tl y
  end.
```
